### PR TITLE
test: trim whitespace before matching

### DIFF
--- a/test.js
+++ b/test.js
@@ -12,6 +12,6 @@ tape('should render on the server', function (t) {
   })
   var res = app.toString('/')
   var exp = '<p>Hello filthy planet</p>'
-  t.equal(res.toString(), exp, 'result was OK')
+  t.equal(res.toString().trim(), exp, 'result was OK')
   t.end()
 })


### PR DESCRIPTION
Avoid testing whitespace in strictEquals, in:
```console
TAP version 13
# should render on the server
not ok 1 result was OK
  ---
    operator: equal
    expected: '<p>Hello filthy planet</p>'
    actual:   '\n      <p>Hello filthy planet</p>\n    '
    at: Test.<anonymous> (/Users/jbergstroem/Work/choo/test.js:15:5)
    stack: |-
      Error: result was OK
          at Test.assert [as _assert] (/Users/jbergstroem/Work/choo/node_modules/tape/lib/test.js:212:54)
          at Test.bound [as _assert] (/Users/jbergstroem/Work/choo/node_modules/tape/lib/test.js:64:32)
          at Test.equal.Test.equals.Test.isEqual.Test.is.Test.strictEqual.Test.strictEquals (/Users/jbergstroem/Work/choo/node_modules/tape/lib/test.js:347:10)
          at Test.bound [as equal] (/Users/jbergstroem/Work/choo/node_modules/tape/lib/test.js:64:32)
          at Test.<anonymous> (/Users/jbergstroem/Work/choo/test.js:15:5)
          at Test.bound [as _cb] (/Users/jbergstroem/Work/choo/node_modules/tape/lib/test.js:64:32)
          at Test.run (/Users/jbergstroem/Work/choo/node_modules/tape/lib/test.js:83:10)
          at Test.bound [as run] (/Users/jbergstroem/Work/choo/node_modules/tape/lib/test.js:64:32)
          at Immediate.next (/Users/jbergstroem/Work/choo/node_modules/tape/lib/results.js:71:15)
          at runCallback (timers.js:800:20)
  ...

1..1
# tests 1
# pass  0
# fail  1
```