### PR TITLE
fix .toString() state (#531)

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ Choo.prototype.mount = function mount (selector) {
 }
 
 Choo.prototype.toString = function (location, state) {
-  this.state = xtend(this.state || {}, state || {})
+  this.state = xtend(this.state, state || {})
 
   assert.notEqual(typeof window, 'object', 'choo.mount: window was found. .toString() must be called in Node, use .start() or .mount() if running in the browser')
   assert.equal(typeof location, 'string', 'choo.toString: location should be type string')

--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ Choo.prototype.mount = function mount (selector) {
 }
 
 Choo.prototype.toString = function (location, state) {
-  this.state = xtend({ events: xtend(this._events) }, this.state || {})
+  this.state = xtend(state, this.state || {})
 
   assert.notEqual(typeof window, 'object', 'choo.mount: window was found. .toString() must be called in Node, use .start() or .mount() if running in the browser')
   assert.equal(typeof location, 'string', 'choo.toString: location should be type string')

--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ Choo.prototype.mount = function mount (selector) {
 }
 
 Choo.prototype.toString = function (location, state) {
-  this.state = xtend(state, this.state || {})
+  this.state = xtend(this.state || {}, state || {})
 
   assert.notEqual(typeof window, 'object', 'choo.mount: window was found. .toString() must be called in Node, use .start() or .mount() if running in the browser')
   assert.equal(typeof location, 'string', 'choo.toString: location should be type string')


### PR DESCRIPTION
Fixed a bug where `.toString()` method was not extending the `state` object properly: https://github.com/choojs/choo/issues/531