### PR TITLE
Expose nanobus

### DIFF
--- a/ee.js
+++ b/ee.js
@@ -1,0 +1,1 @@
+module.exports = require('nanobus')


### PR DESCRIPTION
Not sure if this is a wanted feature, but here we go.

Currenty `bel` is exposed so one can import it by `choo/html`. This expoes nanobus in the same way on `choo/ee`.

Main reason for this is that there are many places one would benefit from using an event emitter to do stuff in an application where the code is not directly bound to choo but the code lives among choo (example of such code can be code doing operations on a map). 

If one have such, its desirable to be able to use the same event emitter, and version, as bundeled in choo to reduce the final bundle size. By being able to get hold of the event emitter in choo like this one will be a bit more safeguarded on this. 