### PR TITLE
Add typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+/// <reference types="node" />
+
+import * as EventEmitter from 'events'
+
+export = Choo
+
+declare class Choo {
+  constructor (opts: Choo.IChoo)
+  use (callback: (state: Choo.IState, emitter: EventEmitter) => void): void
+  route (routeName: string, handler: (state: Choo.IState, emit: (name: string, ...args: any[]) => void) => void): void
+  mount (selector: string): void
+  start (): HTMLElement
+  toString (location: string, state?: Choo.IState): string
+}
+
+declare namespace Choo {
+  export interface IChoo {
+    history?: boolean
+    href?: boolean
+  }
+
+  export interface IState {
+    events: {
+      [key: string]: string
+    }
+    params: {
+      [key: string]: string
+    }
+    query?: {
+      [key: string]: string
+    }
+    href: string
+    route: string
+    title: string
+    [key: string]: any
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "@types/node": "^8.0.20",
     "browserify": "^14.3.0",
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^2.8.0",


### PR DESCRIPTION
Don't want to bikeshed on whether people like TypeScript or not :).

But here is a defintion file that TypeScript users can pick up and use.

I'm working on one for nanocomponent and nanobus (when the nanobus one is done
I'll update this PR so that it uses that instead of the node EventEmitter
definition, although I think they'll be the same...)

The question is do we want this in the project (adds a few K at best, and will
be ignored when the project is browserified), or should I add this to
DefinitelyTyped.

I totally prefer the typing to be in the file since there's no extra dep that
has be to be installed.