### PR TITLE
Fire route event after render if the url has changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ function Choo (opts) {
     PUSHSTATE: 'pushState',
     NAVIGATE: 'navigate',
     POPSTATE: 'popState',
-    RENDER: 'render'
+    RENDER: 'render',
+    ROUTE: 'route'
   }
 
   // properties for internal use only
@@ -132,11 +133,19 @@ Choo.prototype.start = function () {
 
   this.emitter.prependListener(self._events.RENDER, nanoraf(function () {
     var renderTiming = nanotiming('choo.render')
+    var oldHref = self.state.href + ''
 
     self.state.href = self._createLocation()
-    var newTree = self.router(self.state.href)
-    assert.ok(newTree, 'choo.render: no valid DOM node returned for location ' + self.state.href)
 
+    var newTree = self.router(self.state.href)
+
+    if (oldHref !== self.state.href) {
+      setTimeout(function () {
+        self.emitter.emit(self._events.ROUTE)
+      }, 1)
+    }
+
+    assert.ok(newTree, 'choo.render: no valid DOM node returned for location ' + self.state.href)
     assert.equal(self._tree.nodeName, newTree.nodeName, 'choo.render: The target node <' +
       self._tree.nodeName.toLowerCase() + '> is not the same type as the new node <' +
       newTree.nodeName.toLowerCase() + '>.')


### PR DESCRIPTION
I believe this addresses #530 by adding an additional event name `route`. I think we sort of need a new event anyways to maintain compatibility.

This is perhaps a naive implementation, but just wanted to get this out there to get feedback.

I have tried moving the event emit around inside this function and I found the setTimeout to be necessary as I believe we need to wait for the internal router events to fire.

Anyways, let me know what you think!

P.S. Happy to add to docs too. I tried the test suite, but was unable to build out of the box on Windoze.