### PR TITLE
Fix toString removing last letter in href

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ Choo.prototype.toString = function (location, state) {
   assert.equal(typeof location, 'string', 'choo.toString: location should be type string')
   assert.equal(typeof this.state, 'object', 'choo.toString: state should be type object')
 
-  this.state.href = location.replace(/\?*.$/, '')
+  this.state.href = location.replace(/\?.+$/, '')
   this.state.query = nanoquery(location)
   var html = this.router(location)
   assert.ok(html, 'choo.toString: no valid value returned for the route ' + location)


### PR DESCRIPTION
The regex in `toString` that (what I assume) is supposed to strip out the query from `state.href` also removes the last letter of the href if there's no query.