### PR TITLE
use .storeName during tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,11 @@ Initialize a new `choo` instance. `opts` can also contain the following values:
 Call a function and pass it a `state` and `emitter`. `emitter` is an instance
 of [nanobus](https://github.com/choojs/nanobus/). You can listen to
 messages by calling `emitter.on()` and emit messages by calling
-`emitter.emit()`.
+`emitter.emit()`. Callbacks passed to `app.use()` are commonly referred to as
+`'stores'`.
+
+If the callback has a `.storeName` property on it, it will be used to identify
+the callback during tracing.
 
 See [#events](#events) for an overview of all events.
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,9 @@ Choo.prototype.route = function (route, handler) {
 
 Choo.prototype.use = function (cb) {
   assert.equal(typeof cb, 'function', 'choo.use: cb should be type function')
-  var endTiming = nanotiming('choo.use')
+  var msg = 'choo.use'
+  msg = cb.storeName ? msg + '(' + cb.storeName + ')' : msg
+  var endTiming = nanotiming(msg)
   cb(this.state, this.emitter, this)
   endTiming()
 }


### PR DESCRIPTION
This allows tracing individual stores by providing a `.storeName` property on the store. I tried going for `.name` first, but it gets mangled during minification. Ties into https://github.com/choojs/choo-devtools/issues/8; would be cool if we could provide a neato boot cost breakdown, including stores.

The step after this would be to add it to all of our `choojs` org stores.

Thanks!