### PR TITLE
chore(pkg): banish lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage.json
 .DS_Store
 *.swp
 .zuulrc
+package-lock.json
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
I noticed in a recent PR there was a commit deleting a generated lock file. I think it would be best disable generation of the lock file for this project to reduce the possibility of lock files being unintentionally committed.