### PR TITLE
deps: update bel to 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bel": "^5.0.1",
+    "bel": "^5.1.3",
     "document-ready": "^2.0.1",
     "nanobus": "^4.2.0",
     "nanohref": "^3.0.0",


### PR DESCRIPTION
Ran into this using `pnpm`:
```console
> choo@6.2.0 deps /Users/jbergstroem/wrk/oss/choo
> dependency-check --entry ./html/index.js . && dependency-check . --extra --no-dev --entry ./html/index.js

Success! All dependencies used in the code are listed in package.json
Success! All dependencies in package.json are used in the code
module.js:529
    throw err;
    ^

Error: Cannot find module 'bel/raw'
    at Function.Module._resolveFilename (module.js:527:15)
    at Function.Module._load (module.js:476:23)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/jbergstroem/wrk/oss/choo/html/raw.js:1:80)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
```

Looks like it was fixed in a newer version of bel. Lets bump.