### PR TITLE
package: prepublish -> prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "mkdir -p dist/ && browserify index -p bundle-collapser/plugin > dist/bundle.js && browserify index -g unassertify -g uglifyify -p bundle-collapser/plugin | uglifyjs --mangle-props -c unsafe,properties,dead_code,comparisons,evaluate,hoist_funs,if_return,join_vars,pure_getters,reduce_vars,collapse_vars --toplevel > dist/bundle.min.js && cat dist/bundle.min.js | gzip --best --stdout | wc -c | pretty-bytes",
     "deps": "dependency-check --entry ./html/index.js . && dependency-check . --extra --no-dev --entry ./html/index.js",
     "inspect": "browserify --full-paths index -g unassertify -g uglifyify | discify --open",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "start": "bankai start example",
     "test": "standard && npm run deps && node test.js"
   },


### PR DESCRIPTION
`prepublish` is deprecated in favor of `prepare` and `prepublishOnly`. Seeing how we want `npm run build` invoked only prior to publishing, opt for `prepublishOnly`.

This has the potential downside of raising lowest required npm to 4.

Refs: https://github.com/npm/npm/issues/10074