### PR TITLE
add initial state support

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ Choo comes with a shared state object. This object can be mutated freely, and
 is passed into the view functions whenever `'render'` is emitted. The state
 object comes with a few properties set.
 
+When initializing the application, `window.initialState` is used to provision
+the initial state. This is especially useful when combined with server
+rendering. See [server rendering](#server-rendering) for more details.
+
 ### `state.events`
 A mapping of Choo's built in events. It's recommended to extend this object
 with your application's events. By defining your event names once and setting
@@ -295,8 +299,8 @@ To can navigate routes you can emit `'pushState'`, `'popState'` or
 `'replaceState'`. See [#events](#events) for more details about these events.
 
 ## Server Rendering
-Choo was built with Node in mind. To render on the server call `.toString()` on
-your application.
+Choo was built with Node in mind. To render on the server call
+`.toString(route, [state])` on your application.
 
 ```js
 var html = require('choo/html')
@@ -312,6 +316,22 @@ var string = app.toString('/', state)
 
 console.log(string)
 // => '<div>Hello Node</div>'
+```
+
+When starting an application in the browser, it's recommended to provide the
+same `state` object available as `window.initialState`. When the application is
+started, it'll be used to initialize the application state. The process of
+server rendering, and providing an initial state on the client to create the
+exact same document is also known as "rehydration".
+
+```html
+<html>
+  <head>
+    <script>window.initialState = { initial: 'state' }</script>
+  </head>
+  <body>
+  </body>
+</html>
 ```
 
 ## Optimizations

--- a/README.md
+++ b/README.md
@@ -324,6 +324,9 @@ started, it'll be used to initialize the application state. The process of
 server rendering, and providing an initial state on the client to create the
 exact same document is also known as "rehydration".
 
+For security purposes, after `window.initialState` is used it is deleted from
+the `window` object.
+
 ```html
 <html>
   <head>

--- a/index.js
+++ b/index.js
@@ -47,9 +47,12 @@ function Choo (opts) {
   this.emitter = nanobus('choo.emit')
 
   var events = { events: this._events }
-  this.state = this.hasWindow && window.initialState
-    ? xtend(window.initialState, events)
-    : events
+  if (this.hasWindow) {
+    this.state = window.initialState
+      ? xtend(window.initialState, events)
+      : events
+    delete window.initialState
+  }
 
   // listen for title changes; available even when calling .toString()
   if (this._hasWindow) this.state.title = document.title

--- a/index.js
+++ b/index.js
@@ -45,7 +45,11 @@ function Choo (opts) {
   // properties that are part of the API
   this.router = nanorouter({ curry: true })
   this.emitter = nanobus('choo.emit')
-  this.state = { events: this._events }
+
+  var events = { events: this._events }
+  this.state = this.hasWindow && window.initialState
+    ? xtend(window.initialState, events)
+    : events
 
   // listen for title changes; available even when calling .toString()
   if (this._hasWindow) this.state.title = document.title

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ function Choo (opts) {
       ? xtend(window.initialState, events)
       : events
     delete window.initialState
+  } else {
+    this.state = events
   }
 
   // listen for title changes; available even when calling .toString()


### PR DESCRIPTION
Allows checking `window.initialState` when booting, so server rendering actually can do a full rehydration step without any hiccups. Thanks!