### PR TITLE
Populate state.query before calling router

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,8 +126,8 @@ Choo.prototype.start = function () {
   }
 
   this.state.href = this._createLocation()
-  this._tree = this.router(this.state.href)
   this.state.query = nanoquery(window.location.search)
+  this._tree = this.router(this.state.href)
   assert.ok(this._tree, 'choo.start: no valid DOM node returned for location ' + this.state.href)
 
   this.emitter.prependListener(self._events.RENDER, nanoraf(function () {


### PR DESCRIPTION
This just ensures that `state.query` is populated before you invoke the router in `choo.start`. Previously I think if you'd had something like:

```js
var app = choo()
app.route('/hello', state => html`<p>Hello ${state.query.name}</p>`)
app.start()
```

and you booted the app on `/hello?name=world` you would see an error because `state.query` was undefined. It would work fine if you *navigated* to that url from within your app because the querystring is also set here: https://github.com/choojs/choo/blob/master/index.js#L93. I would guess that with this change you could remove that line, but I'm not totally confident of that.