### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ var choo = require('choo')
 var app = choo()
 app.use(log())
 app.use(countStore)
-app.route('/', mainView)
+app.route('*', mainView)
 app.mount('body')
 
 function mainView (state, emit) {


### PR DESCRIPTION
> `'*'` works in more cases than `'/'` (eg. GithubPages). Prevent errors for beginners.

It did take me a while to figure that error out...