### PR TITLE
Add optionality to 'opts' in Choo constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import * as EventEmitter from 'events'
 export = Choo
 
 declare class Choo {
-  constructor (opts: Choo.IChoo)
+  constructor (opts?: Choo.IChoo)
   use (callback: (state: Choo.IState, emitter: EventEmitter) => void): void
   route (routeName: string, handler: (state: Choo.IState, emit: (name: string, ...args: any[]) => void) => void): void
   mount (selector: string): void


### PR DESCRIPTION
This PR makes `opts` parameter in constructor optional, because choo has a code to resolve the parameter if it is undefined: https://github.com/choojs/choo/blob/master/index.js#L20