### PR TITLE
Add ES6 'export default' compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 import * as EventEmitter from 'events'
 
-export = Choo
+export default Choo
 
 declare class Choo {
   constructor (opts: Choo.IChoo)

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var assert = require('assert')
 var xtend = require('xtend')
 
 module.exports = Choo
+module.exports["default"] = Choo
 
 var HISTORY_OBJECT = {}
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var assert = require('assert')
 var xtend = require('xtend')
 
 module.exports = Choo
-module.exports["default"] = Choo
+module.exports['default'] = Choo
 
 var HISTORY_OBJECT = {}
 


### PR DESCRIPTION
Currently, this module does not have a good compatibility with ES6 'export default' syntax. This PR adds it.