### PR TITLE
Fix missing underscore in _hasWindow

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function Choo (opts) {
   this.emitter = nanobus('choo.emit')
 
   var events = { events: this._events }
-  if (this.hasWindow) {
+  if (this._hasWindow) {
     this.state = window.initialState
       ? xtend(window.initialState, events)
       : events


### PR DESCRIPTION
The initial state was not being set to `window.initialState` due to the condition for doing so never resolved to true (the underscore in `this._hasWindow` was missing).