### PR TITLE
add support for HTMLElement on choo.mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ See [#routing](#routing) for an overview of how to use routing efficiently.
 
 ### `app.mount(selector)`
 Start the application and mount it on the given `querySelector`,
+the given selector can be a String or a DOM element.
 
 This will _replace_ the selector provided with the tree returned from `app.start()`.
 If you want to add the app as a child to an element, use `app.start()` to obtain the tree and manually append it.

--- a/README.md
+++ b/README.md
@@ -453,10 +453,10 @@ hood.
 See [#routing](#routing) for an overview of how to use routing efficiently.
 
 ### `app.mount(selector)`
-Start the application and mount it on the given `querySelector`. Uses
-[nanomount][nanomount] under the hood. This will _replace_ the selector provided
-with the tree returned from `app.start()`. If you want to add the app as a child
-to an element, use `app.start()` to obtain the tree and manually append it.
+Start the application and mount it on the given `querySelector`,
+
+This will _replace_ the selector provided with the tree returned from `app.start()`.
+If you want to add the app as a child to an element, use `app.start()` to obtain the tree and manually append it.
 
 ### `tree = app.start()`
 Start the application. Returns a tree of DOM nodes that can be mounted using
@@ -581,7 +581,6 @@ Become a backer, and buy us a coffee (or perhaps lunch?) every month or so.
 [morphdom-bench]: https://github.com/patrick-steele-idem/morphdom#benchmarks
 [nanomorph]: https://github.com/choojs/nanomorph
 [nanorouter]: https://github.com/choojs/nanorouter
-[nanomount]: https://github.com/yoshuawuyts/nanomount
 [yo-yo]: https://github.com/maxogden/yo-yo
 [yo-yoify]: https://github.com/shama/yo-yoify
 [unassertify]: https://github.com/unassert-js/unassertify

--- a/index.js
+++ b/index.js
@@ -179,9 +179,7 @@ Choo.prototype.mount = function mount (selector) {
     if (typeof selector === 'string') {
       self._tree = document.querySelector(selector)
     } else {
-      if (selector instanceof window.HTMLElement) {
-        self._tree = selector
-      }
+      self._tree = selector
     }
 
     assert.ok(self._tree, 'choo.mount: could not query selector: ' + selector)

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ Choo.prototype.start = function () {
 
 Choo.prototype.mount = function mount (selector) {
   assert.equal(typeof window, 'object', 'choo.mount: window was not found. .mount() must be called in a browser, use .toString() if running in Node')
-  assert.equal(typeof selector, 'string', 'choo.mount: selector should be type string')
+  assert.ok(selector, 'choo.mount: selector should be type string or HTMLElement');
 
   var self = this
 
@@ -177,7 +177,12 @@ Choo.prototype.mount = function mount (selector) {
     var renderTiming = nanotiming('choo.render')
     var newTree = self.start()
 
-    self._tree = document.querySelector(selector)
+    if (typeof selector === 'string') {
+        self._tree = document.querySelector(selector)
+    } else if (selector instanceof HTMLElement) {
+        self._tree = selector;
+    }
+
     assert.ok(self._tree, 'choo.mount: could not query selector: ' + selector)
     assert.equal(self._tree.nodeName, newTree.nodeName, 'choo.mount: The target node <' +
       self._tree.nodeName.toLowerCase() + '> is not the same type as the new node <' +

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ Choo.prototype.start = function () {
 
 Choo.prototype.mount = function mount (selector) {
   assert.equal(typeof window, 'object', 'choo.mount: window was not found. .mount() must be called in a browser, use .toString() if running in Node')
-  assert.ok(selector, 'choo.mount: selector should be type string or HTMLElement');
+  assert.ok(selector, 'choo.mount: selector should be type string or HTMLElement')
 
   var self = this
 
@@ -178,9 +178,9 @@ Choo.prototype.mount = function mount (selector) {
     var newTree = self.start()
 
     if (typeof selector === 'string') {
-        self._tree = document.querySelector(selector)
+      self._tree = document.querySelector(selector)
     } else if (selector instanceof HTMLElement) {
-        self._tree = selector;
+      self._tree = selector
     }
 
     assert.ok(self._tree, 'choo.mount: could not query selector: ' + selector)

--- a/index.js
+++ b/index.js
@@ -176,11 +176,12 @@ Choo.prototype.mount = function mount (selector) {
   documentReady(function () {
     var renderTiming = nanotiming('choo.render')
     var newTree = self.start()
-
     if (typeof selector === 'string') {
       self._tree = document.querySelector(selector)
-    } else if (selector instanceof HTMLElement) {
-      self._tree = selector
+    } else if (self._hasWindow) {
+      if (selector instanceof HTMLElement) {
+        self._tree = selector
+      }
     }
 
     assert.ok(self._tree, 'choo.mount: could not query selector: ' + selector)

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ Choo.prototype.mount = function mount (selector) {
     if (typeof selector === 'string') {
       self._tree = document.querySelector(selector)
     } else if (self._hasWindow) {
-      if (selector instanceof HTMLElement) {
+      if (selector instanceof window.HTMLElement) {
         self._tree = selector
       }
     }

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ Choo.prototype.start = function () {
 
 Choo.prototype.mount = function mount (selector) {
   assert.equal(typeof window, 'object', 'choo.mount: window was not found. .mount() must be called in a browser, use .toString() if running in Node')
-  assert.ok(selector, 'choo.mount: selector should be type string or HTMLElement')
+  assert.ok(typeof selector === 'string' || typeof selector === 'object', 'choo.mount: selector should be type String or HTMLElement')
 
   var self = this
 
@@ -178,7 +178,7 @@ Choo.prototype.mount = function mount (selector) {
     var newTree = self.start()
     if (typeof selector === 'string') {
       self._tree = document.querySelector(selector)
-    } else if (self._hasWindow) {
+    } else {
       if (selector instanceof window.HTMLElement) {
         self._tree = selector
       }


### PR DESCRIPTION
Hi, this pull request adds support for HTMLElements, as parameter for choo.mount()

What is done:
- removed explicit "string" test for "selector" variable, replaced by "is available and filled" test
- add "if" to fill "self._tree" by incoming "string" or "HTMLElement" (with is in Browser check)

