### PR TITLE
Support async routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,12 +146,12 @@ Choo.prototype.start = function () {
     self.state.href = self._createLocation()
 
     var res = self.router(self.state.href)
-    if (typeof res === 'string' || (self._hasWindow && res instanceof window.HTMLElement)) {
+    if (self._hasWindow && res instanceof window.HTMLElement) {
       self.morph(res)
       renderTiming()
     } else if (res && typeof res.then === 'function') {
       res.then(function (tree) {
-        assert.ok(typeof res === 'string' || (self._hasWindow && res instanceof window.HTMLElement))
+        assert.ok(self._hasWindow && res instanceof window.HTMLElement)
         self.morph(tree)
         renderTiming()
       })
@@ -215,7 +215,8 @@ Choo.prototype.toString = function (location, state) {
 
   this.state.href = location.replace(/\?.+$/, '')
   this.state.query = nanoquery(location)
-  var html = this.router(location)
-  assert.ok(html, 'choo.toString: no valid value returned for the route ' + location)
-  return html.toString()
+  var res = this.router(location)
+  assert.ok(res, 'choo.toString: no valid value returned for the route ' + location)
+  assert.ok(typeof res.then !== 'function', 'choo.toString: not possible to stringify async route' + location)
+  return res.toString()
 }

--- a/test.js
+++ b/test.js
@@ -18,17 +18,19 @@ tape('should render on the server', function (t) {
   t.end()
 })
 
-tape('should render async route', function (t) {
+tape('async route should throw on server', function (t) {
   var app = choo()
-  app.route('/', function (state, emit) {
-    return new Promise(function (resolve) {
-      var strong = '<strong>Hello filthy planet</strong>'
-      resolve(html`<p>${raw(strong)}</p>`)
-    })
+  app.route('/', async function (state, emit) {
+    var strong = '<strong>Hello filthy planet</strong>'
+    return html`
+      <p>${raw(strong)}</p>
+    `
   })
-  app.toString('/').then(function (res) {
-    var exp = '<p><strong>Hello filthy planet</strong></p>'
-    t.equal(res.trim(), exp, 'result was OK')
-    t.end()
-  })
+  try {
+    var res = app.toString('/')
+    t.notOk(res, 'this should not be executed')
+  } catch (e) {
+    t.ok(e, 'throws expected error')
+  }
+  t.end()
 })

--- a/test.js
+++ b/test.js
@@ -17,3 +17,18 @@ tape('should render on the server', function (t) {
   t.equal(res.toString().trim(), exp, 'result was OK')
   t.end()
 })
+
+tape('should render async route', function (t) {
+  var app = choo()
+  app.route('/', function (state, emit) {
+    return new Promise(function (resolve) {
+      var strong = '<strong>Hello filthy planet</strong>'
+      resolve(html`<p>${raw(strong)}</p>`)
+    })
+  })
+  app.toString('/').then(function (res) {
+    var exp = '<p><strong>Hello filthy planet</strong></p>'
+    t.equal(res.trim(), exp, 'result was OK')
+    t.end()
+  })
+})


### PR DESCRIPTION
This probably shouldn't be merged yet, just opening this PR for feedback/discussion.

In this PR I've implemented (part of) the API I proposed [here](https://github.com/choojs/choo/issues/563#issuecomment-344733106). After playing around with it a bit I initially [got stuck](https://github.com/choojs/choo/issues/563#issuecomment-346887984) when trying to make my changes work with the synchronous `toString` API. But then I realized we could just decide not to support `toString` on async routes and throw an AssertionError when anyone tries it. Thoughts?