### PR TITLE
Introduce pre-render `resolve` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ Choo.prototype.start = function () {
       self.state.query = nanoquery(window.location.search)
       if (self._loaded) {
         var resList = self.emitter._listeners[self._events.RESOLVE]
-        var resCount = resList ? resList.length : 0;
+        var resCount = resList ? resList.length : 0
         self.emitter.emit(resCount > 0 ? self._events.RESOLVE : self._events.RENDER)
       }
     })


### PR DESCRIPTION
Since my experiments with async routing on [this branch](https://github.com/choojs/choo/pull/602) have been a bit of a struggle so far, this is a potential alternative. This approach starts from the idea that the proper way to do async stuff within the current architecture is through `nanobus`, and that the routing logic is best kept fully synchronous.

This implementation checks if the developer has registered any `resolve` listeners in the application. If yes, that/those listeners are triggered instead of `render`, and the developer is responsible for triggering `render` from there. If no `resolve` listeners are registered, the current behaviour for `render` is kept.

An example of an asynchronously rendered route using this API would be:

```js
app.use(function (state, bus) {
    bus.on('resolve', function() {
        if (state.route !== '/async') {
            return bus.emit('render')
        }
        http.get('https://api.example.com' + state.route, function (err, data) {
            if (err) return handle(err)
            state.data = data
            bus.emit('render')
        })
    })
})

// standard synchronous routes:
app.route('/', home)
app.route('/sync', viewSyncData)
// route that asynchronously displays `state.data`:
app.route('/async', viewAsyncData)
```

This implementation is already much more stable than my experiment on the other branch, but I'm not sure if the API would work for everyone. Feedback welcome!