### PR TITLE
Allow initial state to be set in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,13 +47,13 @@ function Choo (opts) {
   this.emitter = nanobus('choo.emit')
 
   var events = { events: this._events }
-  if (this._hasWindow) {
-    this.state = window.initialState
-      ? xtend(window.initialState, events)
-      : events
+  var initialState = xtend(opts.initialState, events)
+
+  if (this._hasWindow && window.initialState) {
+    this.state = xtend(window.initialState, initialState)
     delete window.initialState
   } else {
-    this.state = events
+    this.state = initialState
   }
 
   // listen for title changes; available even when calling .toString()


### PR DESCRIPTION
Allows the inital state to be set in the options passed to the `Choo` function. To set an initial state, just set the `initialState` option.

I also cleaned up the code around setting the initial state from the `window` object.