### PR TITLE
Separate route matching from rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "nanomorph": "^5.1.2",
     "nanoquery": "^1.1.0",
     "nanoraf": "^3.0.0",
-    "nanorouter": "^2.0.0",
+    "nanorouter": "^3.0.1",
     "nanotiming": "^6.0.0",
     "scroll-to-anchor": "^1.0.0",
     "xtend": "^4.0.1"


### PR DESCRIPTION
This PR
- Fixes the routing to modify the state before the navigate event happens. This means you can access the updated state within the `navigate` event. Modifies the state before the render event is triggered. Therefore this fixes #530, #553, #549, #610
- Exposes `.emit` as an alias to `.emitter.emit`
- Theoretically supports nested routes 😁 . But because we didn't document nor test the router in this repo, I'd handle that as private api for now.

Additionally to the changes I did in here I think we should
  - [x] Define what's the responsiblity of nanorouter & wayfarer and how we could modularize it better
     (I guess this is done by now as nanorouter contains some electron-, and browser specific logic)
  - [x] Deprecate `curry` support in nanorouter. People could just wrap their method by themselves

Please let me know what you think

- [x] Before merging this PR, we have to cleanup the nanorouter dependency.
- [ ] We'll also need to rename some methods and expose the `_handler` differently on the state if we decide to go down this path. In case we want to be able to cancel a navigate event in the future, we could also make it more stateless and pass the new route as object to the navigate events instead of modifying the state.