### PR TITLE
Fix TodoMVC example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "test": "standard && node test.js"
   },
   "dependencies": {
-    "choo-devtools": "2.0.0",
+    "choo-devtools": "^2.3.3",
     "sheetify": "^6.0.1",
     "todomvc-app-css": "^2.0.6",
     "todomvc-common": "^1.0.3"


### PR DESCRIPTION
In choo-devtools@2.0.0 there were some conflicting methods.

On https://github.com/choojs/choo-devtools/blob/v2.0.0/index.js#L37
`window.choo.log` was set, which was a getter defined in
https://github.com/choojs/choo-devtools/blob/v2.0.0/lib/log.js#L21

This basically broke the whole app.
Updating the dependency helped as those lines got replaced.