### PR TITLE
add support for hyperscript in choo.toString

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ Choo.prototype.toString = function (location, state) {
   this._matchRoute(location)
   var html = this._prerender(this.state)
   assert.ok(html, 'choo.toString: no valid value returned for the route ' + location)
-  return html.toString()
+  return typeof html.outerHTML === 'string' ? html.outerHTML : html.toString()
 }
 
 Choo.prototype._matchRoute = function (locationOverride) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^2.8.0",
     "discify": "^1.6.0",
+    "hyperscript": "^2.0.2",
     "pretty-bytes-cli": "^2.0.0",
     "spok": "^0.8.1",
     "standard": "^10.0.0",

--- a/test.js
+++ b/test.js
@@ -1,16 +1,28 @@
 var tape = require('tape')
+var h = require('hyperscript')
 
 var html = require('./html')
 var raw = require('./html/raw')
 var choo = require('./')
 
-tape('should render on the server', function (t) {
+tape('should render on the server with bel', function (t) {
   var app = choo()
   app.route('/', function (state, emit) {
     var strong = '<strong>Hello filthy planet</strong>'
     return html`
       <p>${raw(strong)}</p>
     `
+  })
+  var res = app.toString('/')
+  var exp = '<p><strong>Hello filthy planet</strong></p>'
+  t.equal(res.toString().trim(), exp, 'result was OK')
+  t.end()
+})
+
+tape('should render on the server with hyperscript', function (t) {
+  var app = choo()
+  app.route('/', function (state, emit) {
+    return h('p', h('strong', 'Hello filthy planet'))
   })
   var res = app.toString('/')
   var exp = '<p><strong>Hello filthy planet</strong></p>'


### PR DESCRIPTION
Resolves #634 (see issue for discussion).

Using the more defensive line to ensure `outerHTML` is a string, otherwise defaulting to `html.toString()`.

I added hyperscript as a dev dependency for the sake of tests, hope that's ok!