### PR TITLE
Add gitignore inside example/

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+package-lock.json

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/


### PR DESCRIPTION
`"example"` is in the `"files"` key in our package.json, which overrides
the root .gitignore and ends up including the entire examples folder,
including its dist/ and node_modules/. That means a fresh install of
choo comes in at over 100MB of unused code.

Nested .gitignores still apply to folders that are specified in the
`files` key, so this pushes choo back down to a <500KB installed size :)
The example code itself is still included so folks can use it as
offline documentation.