### PR TITLE
assert for arrays on .toString()

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,6 +208,7 @@ Choo.prototype.toString = function (location, state) {
   this._matchRoute(location)
   var html = this._prerender(this.state)
   assert.ok(html, 'choo.toString: no valid value returned for the route ' + location)
+  assert(!Array.isArray(html), 'choo.toString: return value was an array for the route ' + location)
   return typeof html.outerHTML === 'string' ? html.outerHTML : html.toString()
 }
 


### PR DESCRIPTION
Found out about an edge case through DMs, reroduced in https://github.com/yoshuawuyts/repro-nanohtml-render-array. Apparently we were allowing top-level arrays to slip through, causing all sorts of funky rendering. This fixes that. Thanks!