### PR TITLE
Immutable state on SSR (toString)

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,6 +208,7 @@ Choo.prototype.mount = function mount (selector) {
 Choo.prototype.toString = function (location, state) {
   state = state || {}
   state.events = xtend(this._events)
+  state.components = state.components || {}
 
   assert.notEqual(typeof window, 'object', 'choo.mount: window was found. .toString() must be called in Node, use .start() or .mount() if running in the browser')
   assert.equal(typeof location, 'string', 'choo.toString: location should be type string')

--- a/test.js
+++ b/test.js
@@ -228,3 +228,37 @@ tape('state should include cache', function (t) {
     t.equal(arg, 'arg', 'constructor args were forwarded')
   }
 })
+
+tape('state should not mutate on toString', function (t) {
+  t.plan(6)
+
+  var app = choo()
+  app.use(store)
+
+  var routes = ['foo', 'bar']
+  var states = routes.map(function (route) {
+    var state = {}
+    app.route(`/${route}`, view)
+    app.toString(`/${route}`, state)
+    return state
+  })
+
+  for (var i = 0, len = routes.length; i < len; i++) {
+    t.equal(states[i].test, routes[i], 'store was used')
+    t.equal(states[i].title, routes[i], 'title was added to state')
+  }
+
+  function store (state, emitter) {
+    state.test = null
+    emitter.on('test', function (str) {
+      t.equal(state.test, null, 'state has been reset')
+      state.test = str
+    })
+  }
+
+  function view (state, emit) {
+    emit('test', state.route)
+    emit(state.events.DOMTITLECHANGE, state.route)
+    return html`<body>Hello ${state.route}</body>`
+  }
+})


### PR DESCRIPTION
This PR solves state leaking between calls to `toString` and race conditions that occur during double render pass (bankai et al.).

The issue is that each call to `toString` would extend `app.state`, adding on more and more data for each render. If one was to expose the resulting `app.state` as `window.initalState` one would get the combined state from all prior calls to `toString`.
It is especially troublesome during double render pass (calling `toString` twice, once to allow events to trigger data being fetched and another to render the view with fetched data). If two attempts at a double render pass are issued in quick succession (e.g. server responding to several requests), both calls will mutate `app.state` and the first to finish will get the intermediate state of both render calls.

This PR ensures that the state passed into `toString` is only modified during that one pass through and that `app.state` remains untouched.

This would also allow us to proceed with https://github.com/choojs/bankai/pull/446

**Edit**: Yet another issue solved by this PR is that every call to `toString` would initialize all stores and hence, add all listeners to the event bus over and over again for every render. This means that after a couple of renders any event listeners that e.g. fetches data will be fetching the same data several times over on every call to `toString`.