### PR TITLE
Fix inspect script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "mkdir -p dist/ && browserify index -s Choo -p bundle-collapser/plugin > dist/bundle.js && browserify index -s Choo -p tinyify > dist/bundle.min.js && cat dist/bundle.min.js | gzip --best --stdout | wc -c | pretty-bytes",
     "deps": "dependency-check --entry ./html/index.js . && dependency-check . --extra --no-dev --entry ./html/index.js --entry ./component/index.js -i nanoassert",
-    "inspect": "browserify --full-paths index -g unassertify -g uglifyify | discify --open",
+    "inspect": "browserify --full-paths index -p tinyify | discify --open",
     "prepublishOnly": "npm run build",
     "start": "bankai start example",
     "test": "standard && npm run deps && node test.js"
@@ -57,15 +57,12 @@
     "browserify": "^16.2.2",
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^3.1.0",
-    "discify": "^1.6.0",
+    "disc": "^1.3.3",
     "hyperscript": "^2.0.2",
     "pretty-bytes-cli": "^2.0.0",
     "spok": "^0.9.1",
     "standard": "^11.0.1",
     "tape": "^4.6.3",
-    "tinyify": "^2.2.0",
-    "uglify-es": "^3.0.17",
-    "uglifyify": "^5.0.0",
-    "unassertify": "^2.0.4"
+    "tinyify": "^2.2.0"
   }
 }


### PR DESCRIPTION
`discify` is a different module than intended. discify is an alternative
to disc that works as a plugin, but we were using it as a separate
command line program. This switches it out for disc. The disc command
line program is called `discify` which is probably where the confusion
came from.

Also swapped out unassertify and uglifyify for tinyify, which adds tree
shaking.