### PR TITLE
Hash routing opt in

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ containing the key-value mappings exists as `state.query`.
 ### Hash routing
 By default hashes are not taken into account when routing. Using hashes to
 delimit routes (e.g. `/foo#bar`) is supported if the `hash` options set to
-`true`. Regardles, when a hash is found we also check if there's an
+`true`. Regardless, when a hash is found we also check if there's an
 available anchor on the same page, and will scroll the screen to the position.
 Using both hashes in URLs and anchor links on the page is generally not
 recommended.

--- a/README.md
+++ b/README.md
@@ -284,12 +284,12 @@ Querystrings (e.g. `?foo=bar`) are ignored when matching routes. An object
 containing the key-value mappings exists as `state.query`.
 
 ### Hash routing
-By default hashes are not taken into account when routing. Using hashes to
-delimit routes (e.g. `/foo#bar`) is supported if the `hash` options set to
-`true`. Regardless, when a hash is found we also check if there's an
-available anchor on the same page, and will scroll the screen to the position.
-Using both hashes in URLs and anchor links on the page is generally not
-recommended.
+By default hashes are treated as part of the url when routing. Using hashes to
+delimit routes (e.g. `/foo#bar`) can be disabled by setting the `hash`
+[option](#app--chooopts) to `false`. Regardless, when a hash is found we also
+check if there's an available anchor on the same page, and will scroll the
+screen to the position. Using both hashes in URLs and anchor links on the page
+is generally not recommended.
 
 ### Following links
 By default all clicks on `<a>` tags are handled by the router through the
@@ -534,7 +534,9 @@ Initialize a new `choo` instance. `opts` can also contain the following values:
 - __opts.cache:__ default: `undefined`. Override default class cache used by
   `state.cache`. Can be a a `number` (maximum number of instances in cache,
   default `100`) or an `object` with a [nanolru][nanolru]-compatible API.
-- __opts.hash:__ default: `false`. Treat hashes in URLs as part of the pathname, transforming `/foo#bar` to `/foo/bar`. This is useful if the application is not mounted at the website root.
+- __opts.hash:__ default: `true`. Treat hashes in URLs as part of the pathname,
+  transforming `/foo#bar` to `/foo/bar`. This is useful if the application is
+  not mounted at the website root.
 
 ### `app.use(callback(state, emitter, app))`
 Call a function and pass it a `state`, `emitter` and `app`. `emitter` is an instance

--- a/README.md
+++ b/README.md
@@ -284,10 +284,12 @@ Querystrings (e.g. `?foo=bar`) are ignored when matching routes. An object
 containing the key-value mappings exists as `state.query`.
 
 ### Hash routing
-Using hashes to delimit routes is supported out of the box (e.g. `/foo#bar`).
-When a hash is found we also check if there's an available anchor on the same
-page, and will scroll the screen to the position. Using both hashes in URLs and
-anchor links on the page is generally not recommended.
+By default hashes are not taken into account when routing. Using hashes to
+delimit routes (e.g. `/foo#bar`) is supported if the `hash` options set to
+`true`. Regardles, when a hash is found we also check if there's an
+available anchor on the same page, and will scroll the screen to the position.
+Using both hashes in URLs and anchor links on the page is generally not
+recommended.
 
 ### Following links
 By default all clicks on `<a>` tags are handled by the router through the
@@ -532,6 +534,7 @@ Initialize a new `choo` instance. `opts` can also contain the following values:
 - __opts.cache:__ default: `undefined`. Override default class cache used by
   `state.cache`. Can be a a `number` (maximum number of instances in cache,
   default `100`) or an `object` with a [nanolru][nanolru]-compatible API.
+- __opts.hash:__ default: `false`. Treat hashes in URLs as part of the pathname, transforming `/foo#bar` to `/foo/bar`. This is useful if the application is not mounted at the website root.
 
 ### `app.use(callback(state, emitter, app))`
 Call a function and pass it a `state`, `emitter` and `app`. `emitter` is an instance

--- a/index.js
+++ b/index.js
@@ -127,8 +127,9 @@ Choo.prototype.start = function () {
     if (self._hrefEnabled) {
       nanohref(function (location) {
         var href = location.href
+        var hash = location.hash
         if (href === window.location.href) {
-          if (!this._hashEnabled) scrollToAnchor(location.hash)
+          if (!this._hashEnabled && hash) scrollToAnchor(hash)
           return
         }
         self.emitter.emit(self._events.PUSHSTATE, href)

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function Choo (opts) {
   // properties for internal use only
   this._historyEnabled = opts.history === undefined ? true : opts.history
   this._hrefEnabled = opts.href === undefined ? true : opts.href
-  this._hashEnabled = opts.hash === undefined ? false : opts.hash
+  this._hashEnabled = opts.hash === undefined ? true : opts.hash
   this._hasWindow = typeof window !== 'undefined'
   this._cache = opts.cache
   this._loaded = false

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "nanocomponent": "^6.5.0",
     "nanohref": "^3.0.0",
     "nanohtml": "^1.1.0",
-    "nanolocation": "^1.0.0",
     "nanolru": "^1.0.0",
     "nanomorph": "^5.1.2",
     "nanoquery": "^1.1.0",


### PR DESCRIPTION
Resolves #666, resolves #440 

Both newcomers as well as seasoned choo users keep stumbling over this and resolve to hackish workarounds or complex subclassing of choo.

Making hash routing *opt-in*, hash anchors will behave as expected as per browser defaults. By opting into hash routing hashes will be transformed to be a part of the pathname (this is the current default behavior).

Example with default new behavior: https://choo-hash-anchors.glitch.me
Example with hash routing enabled: https://choo-hash-anchors-enabled.glitch.me/my/app

I ended up factoring out [nanolocation](https://github.com/choojs/nanolocation) as the behavior had to be duplicated for location override.

This is most definitely a breaking change.