### PR TITLE
Add documentation on components

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ hold a self-contained state or to not rerender when the application does. This
 is common when using 3rd party libraries to e.g. display an interactive map or a
 graph and you rely on this 3rd party library to handle modifications to the DOM.
 Components come baked in to Choo for these kinds of situations. See
-[nanocomponent][nanocomponent] for documention on the component class.
+[nanocomponent][nanocomponent] for documentation on the component class.
 
 ```javascript
 // map.js


### PR DESCRIPTION
Resolves #662 

A first take on documentation of components in Choo and the new component cache. I wasn't sure about how much detail to go into about the component API seeing as nanocomponent has some excellent docs of its own. Also, I'm not 100% sure it's the best idea to drag in mapbox and and the geolocation API in the example but seeing as the text speaks of 3rd party libraries, it made sense to illustrate that. Maybe the nanocomponent [button example](https://github.com/choojs/nanocomponent#usage) or something like that would suffice?

Would very much appreciate feedback from @yoshuawuyts, @bcomnes and @s3ththompson as they were instrumental in brining this into Choo.