### PR TITLE
Remove references to bel

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,8 +597,6 @@ $ npm install choo
 - [bankai](https://github.com/choojs/bankai) - streaming asset compiler
 - [stack.gl](http://stack.gl/) - open software ecosystem for WebGL
 - [yo-yo](https://github.com/maxogden/yo-yo) - tiny library for modular UI
-- [bel](https://github.com/shama/bel) - composable DOM elements using template
-  strings
 - [tachyons](https://github.com/tachyons-css/tachyons) - functional CSS for
   humans
 - [sheetify](https://github.com/stackcss/sheetify) - modular CSS bundler for
@@ -689,7 +687,6 @@ Become a backer, and buy us a coffee (or perhaps lunch?) every month or so.
 [nanocomponent]: https://github.com/choojs/nanocomponent
 [nanolru]: https://github.com/s3ththompson/nanolru
 [bankai]: https://github.com/choojs/bankai
-[bel]: https://github.com/shama/bel
 [nanohtml]: https://github.com/choojs/nanohtml
 [browserify]: https://github.com/substack/node-browserify
 [budo]: https://github.com/mattdesl/budo

--- a/example/components/footer/clear-button.js
+++ b/example/components/footer/clear-button.js
@@ -1,4 +1,4 @@
-var html = require('bel')
+var html = require('nanohtml')
 
 module.exports = deleteCompleted
 

--- a/example/components/footer/filter-button.js
+++ b/example/components/footer/filter-button.js
@@ -1,4 +1,4 @@
-var html = require('bel')
+var html = require('nanohtml')
 
 module.exports = filterButton
 

--- a/example/components/footer/index.js
+++ b/example/components/footer/index.js
@@ -1,5 +1,5 @@
 var Component = require('../../../component')
-var html = require('bel')
+var html = require('nanohtml')
 
 var clearButton = require('./clear-button')
 var filterButton = require('./filter-button')

--- a/example/components/header.js
+++ b/example/components/header.js
@@ -1,5 +1,5 @@
 var Component = require('../../component')
-var html = require('bel')
+var html = require('nanohtml')
 
 module.exports = class Header extends Component {
   constructor (name, state, emit) {

--- a/example/components/info.js
+++ b/example/components/info.js
@@ -1,5 +1,5 @@
 var Component = require('../../component')
-var html = require('bel')
+var html = require('nanohtml')
 
 module.exports = class Info extends Component {
   update () {

--- a/example/components/todos/index.js
+++ b/example/components/todos/index.js
@@ -1,5 +1,5 @@
 var Component = require('../../../component')
-var html = require('bel')
+var html = require('nanohtml')
 
 var Todo = require('./todo')
 

--- a/example/components/todos/todo.js
+++ b/example/components/todos/todo.js
@@ -1,4 +1,4 @@
-var html = require('bel')
+var html = require('nanohtml')
 
 module.exports = Todo
 

--- a/example/views/main.js
+++ b/example/views/main.js
@@ -1,4 +1,4 @@
-var html = require('bel') // cannot require choo/html because it's a nested repo
+var html = require('nanohtml') // cannot require choo/html because it's a nested repo
 
 var Header = require('../components/header')
 var Footer = require('../components/footer')

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ var html = require('./html')
 var raw = require('./html/raw')
 var choo = require('./')
 
-tape('should render on the server with bel', function (t) {
+tape('should render on the server with nanohtml', function (t) {
   var app = choo()
   app.route('/', function (state, emit) {
     var strong = '<strong>Hello filthy planet</strong>'


### PR DESCRIPTION
This removes the last trailing references to bel in the example and readme. The example would work thanks to the nanohtml transform (part of bankai) but would fail if required (`require('./example')`).