### PR TITLE
Match initial route before stores are called

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,12 +137,13 @@ Choo.prototype.start = function () {
     }
   }
 
+  this._matchRoute()
+
   this._setCache(this.state)
   this._stores.forEach(function (initStore) {
     initStore(self.state)
   })
 
-  this._matchRoute()
   this._tree = this._prerender(this.state)
   assert.ok(this._tree, 'choo.start: no valid DOM node returned for location ' + this.state.href)
 
@@ -211,12 +212,14 @@ Choo.prototype.toString = function (location, state) {
   assert.equal(typeof this.state, 'object', 'choo.toString: state should be type object')
 
   var self = this
+
+  this._matchRoute(location)
+
   this._setCache(this.state)
   this._stores.forEach(function (initStore) {
     initStore(self.state)
   })
 
-  this._matchRoute(location)
   var html = this._prerender(this.state)
   assert.ok(html, 'choo.toString: no valid value returned for the route ' + location)
   assert(!Array.isArray(html), 'choo.toString: return value was an array for the route ' + location)

--- a/test.js
+++ b/test.js
@@ -169,14 +169,20 @@ tape('state should include events', function (t) {
 })
 
 tape('state should include params', function (t) {
-  t.plan(4)
+  t.plan(8)
   var app = choo()
   app.route('/:resource/:id/*', function (state, emit) {
-    t.ok(state.hasOwnProperty('params'), 'state has params property')
-    t.equal(state.params.resource, 'users', 'resources param is users')
-    t.equal(state.params.id, '1', 'id param is 1')
-    t.equal(state.params.wildcard, 'docs/foo.txt', 'wildcard captures what remains')
+    t.ok(state.hasOwnProperty('params'), 'state has params property (view)')
+    t.equal(state.params.resource, 'users', 'resources param is users (view)')
+    t.equal(state.params.id, '1', 'id param is 1 (view)')
+    t.equal(state.params.wildcard, 'docs/foo.txt', 'wildcard captures what remains (view)')
     return html`<div></div>`
+  })
+  app.use(function (state, emitter) {
+    t.ok(state.hasOwnProperty('params'), 'state has params property (store)')
+    t.equal(state.params.resource, 'users', 'resources param is users (store)')
+    t.equal(state.params.id, '1', 'id param is 1 (store)')
+    t.equal(state.params.wildcard, 'docs/foo.txt', 'wildcard captures what remains (store)')
   })
   app.toString('/users/1/docs/foo.txt')
   t.end()
@@ -195,12 +201,16 @@ tape('state should include query', function (t) {
 })
 
 tape('state should include href', function (t) {
-  t.plan(2)
+  t.plan(4)
   var app = choo()
   app.route('/:resource/:id', function (state, emit) {
-    t.ok(state.hasOwnProperty('href'), 'state has href property')
-    t.equal(state.href, '/users/1', 'href is users/1')
+    t.ok(state.hasOwnProperty('href'), 'state has href property (view)')
+    t.equal(state.href, '/users/1', 'href is users/1 (view)')
     return html`<div></div>`
+  })
+  app.use(function (state, emitter) {
+    t.ok(state.hasOwnProperty('href'), 'state has href property (store)')
+    t.equal(state.href, '/users/1', 'href is users/1 (store)')
   })
   app.toString('/users/1?page=2') // should ignore query
   t.end()


### PR DESCRIPTION
Hello choo croo, I just made a store that needs to get a URL param from `state.params` - I was only able to get it after the `DOMContentLoaded` event, which I thought was a bit weird.

Basically, when I navigate to `/thingy/foo`, I'd like to do this:

```js
app.route('/thingy/:id', (state, emit) => html`<div>this is thingy ${state.params.id}</div>`)
app.use((state, emitter) => {
  console.log(state.params.id) // <= expected: foo
  // actual: state.params is undefined :(
  emitter.on('DOMContentLoaded', () => {
    console.log(state.params.id) // this works though
  })
})
```

I see no reason why I shouldn't be able to access the route info directly in the store - as far as I can tell, it doesn't interfere with any of the other things that happen on initial render.

This change just moves the `this._matchRoute` call in `Choo.start` & `Choo.toString` above the initial stores call.

I've added tests for `state.params` & `state.href` being set in the store, and also checked the expected behavior in my store :)