### PR TITLE
Fix wrong this usage in nanohref integration

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ Choo.prototype.start = function () {
         var href = location.href
         var hash = location.hash
         if (href === window.location.href) {
-          if (!this._hashEnabled && hash) scrollToAnchor(hash)
+          if (!self._hashEnabled && hash) scrollToAnchor(hash)
           return
         }
         self.emitter.emit(self._events.PUSHSTATE, href)


### PR DESCRIPTION
I currently see `TypeError: undefined is not an object (evaluating 'this._hashEnabled')` being thrown by clients. This should fix it.