### PR TITLE
Fix location missing on store init

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,11 +212,11 @@ Choo.prototype.toString = function (location, state) {
 
   var self = this
   this._setCache(this.state)
+  this._matchRoute(location)
   this._stores.forEach(function (initStore) {
     initStore(self.state)
   })
 
-  this._matchRoute(location)
   var html = this._prerender(this.state)
   assert.ok(html, 'choo.toString: no valid value returned for the route ' + location)
   assert(!Array.isArray(html), 'choo.toString: return value was an array for the route ' + location)

--- a/test.js
+++ b/test.js
@@ -194,16 +194,39 @@ tape('state should include query', function (t) {
   t.end()
 })
 
-tape('state should include href', function (t) {
-  t.plan(2)
+tape('state should include location on render', function (t) {
+  t.plan(6)
   var app = choo()
-  app.route('/:resource/:id', function (state, emit) {
-    t.ok(state.hasOwnProperty('href'), 'state has href property')
-    t.equal(state.href, '/users/1', 'href is users/1')
+  app.route('/:foo', function (state, emit) {
+    t.equal(state.href, '/foo', 'state has href')
+    t.equal(state.route, ':foo', 'state has route')
+    t.ok(state.hasOwnProperty('params'), 'state has params')
+    t.deepEqual(state.params, { foo: 'foo' }, 'params match')
+    t.ok(state.hasOwnProperty('query'), 'state has query')
+    t.deepEqual(state.query, { bar: 'baz' }, 'query match')
     return html`<div></div>`
   })
-  app.toString('/users/1?page=2') // should ignore query
+  app.toString('/foo?bar=baz')
   t.end()
+})
+
+tape('state should include location on store init', function (t) {
+  t.plan(6)
+  var app = choo()
+  app.use(store)
+  app.route('/:foo', function (state, emit) {
+    return html`<div></div>`
+  })
+  app.toString('/foo?bar=baz')
+
+  function store (state, emit) {
+    t.equal(state.href, '/foo', 'state has href')
+    t.equal(state.route, ':foo', 'state has route')
+    t.ok(state.hasOwnProperty('params'), 'state has params')
+    t.deepEqual(state.params, { foo: 'foo' }, 'params match')
+    t.ok(state.hasOwnProperty('query'), 'state has query')
+    t.deepEqual(state.query, { bar: 'baz' }, 'query match')
+  }
 })
 
 // TODO: Implement this using jsdom, as this only works when window is present


### PR DESCRIPTION
Location meta data was missing on store init during SSR, meaning `href`, `query`, `route` and `params` was missing from state when initializing stores.

This fixes that by running `_matchRoute` before initializing stores during SSR.