### PR TITLE
Match route before init stores

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,11 +138,11 @@ Choo.prototype.start = function () {
   }
 
   this._setCache(this.state)
+  this._matchRoute()
   this._stores.forEach(function (initStore) {
     initStore(self.state)
   })
 
-  this._matchRoute()
   this._tree = this._prerender(this.state)
   assert.ok(this._tree, 'choo.start: no valid DOM node returned for location ' + this.state.href)
 
@@ -212,11 +212,11 @@ Choo.prototype.toString = function (location, state) {
 
   var self = this
   this._setCache(this.state)
+  this._matchRoute(location)
   this._stores.forEach(function (initStore) {
     initStore(self.state)
   })
 
-  this._matchRoute(location)
   var html = this._prerender(this.state)
   assert.ok(html, 'choo.toString: no valid value returned for the route ' + location)
   assert(!Array.isArray(html), 'choo.toString: return value was an array for the route ' + location)

--- a/test/browser.js
+++ b/test/browser.js
@@ -191,6 +191,27 @@ tape('state should include location on render', function (t) {
   app.mount(container)
 })
 
+tape('state should include location on store init', function (t) {
+  t.plan(6)
+  var app = choo()
+  var container = init('/foo/bar/file.txt?bin=baz')
+  app.use(store)
+  app.route('/:first/:second/*', function (state, emit) {
+    return html`<div></div>`
+  })
+  app.mount(container)
+
+  function store (state, emit) {
+    var params = { first: 'foo', second: 'bar', wildcard: 'file.txt' }
+    t.equal(state.href, '/foo/bar/file.txt', 'state has href')
+    t.equal(state.route, ':first/:second/*', 'state has route')
+    t.ok(state.hasOwnProperty('params'), 'state has params')
+    t.deepEqual(state.params, params, 'params match')
+    t.ok(state.hasOwnProperty('query'), 'state has query')
+    t.deepEqual(state.query, { bin: 'baz' }, 'query match')
+  }
+})
+
 tape('state should include title', function (t) {
   t.plan(3)
   document.title = 'foo'

--- a/test/node.js
+++ b/test/node.js
@@ -185,6 +185,26 @@ tape('state should include location on render', function (t) {
   t.end()
 })
 
+tape('state should include location on store init', function (t) {
+  t.plan(6)
+  var app = choo()
+  app.use(store)
+  app.route('/:first/:second/*', function (state, emit) {
+    return html`<div></div>`
+  })
+  app.toString('/foo/bar/file.txt?bin=baz')
+
+  function store (state, emit) {
+    var params = { first: 'foo', second: 'bar', wildcard: 'file.txt' }
+    t.equal(state.href, '/foo/bar/file.txt', 'state has href')
+    t.equal(state.route, ':first/:second/*', 'state has route')
+    t.ok(state.hasOwnProperty('params'), 'state has params')
+    t.deepEqual(state.params, params, 'params match')
+    t.ok(state.hasOwnProperty('query'), 'state has query')
+    t.deepEqual(state.query, { bin: 'baz' }, 'query match')
+  }
+})
+
 tape('state should include cache', function (t) {
   t.plan(6)
   var app = choo()


### PR DESCRIPTION
This adds back the changes made in #695 ensuring that `href`, `query`, `params` etc. are in the state _before_ the stores are initialized.