### PR TITLE
Disable hash routing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,12 +284,12 @@ Querystrings (e.g. `?foo=bar`) are ignored when matching routes. An object
 containing the key-value mappings exists as `state.query`.
 
 ### Hash routing
-By default hashes are treated as part of the url when routing. Using hashes to
-delimit routes (e.g. `/foo#bar`) can be disabled by setting the `hash`
-[option](#app--chooopts) to `false`. Regardless, when a hash is found we also
-check if there's an available anchor on the same page, and will scroll the
-screen to the position. Using both hashes in URLs and anchor links on the page
-is generally not recommended.
+By default, hashes are ignored when routing. When enabling hash routing
+(`choo({ hash: true })`) hashes will be treated as part of the url, converting
+`/foo#bar` to `/foo/bar`. This is useful if the application is not mounted at
+the website root. Unless hash routing is enabled, if a hash is found we check if
+there's an anchor on the same page, and will scroll the element into view. Using
+both hashes in URLs and anchor links on the page is generally not recommended.
 
 ### Following links
 By default all clicks on `<a>` tags are handled by the router through the
@@ -534,7 +534,7 @@ Initialize a new `choo` instance. `opts` can also contain the following values:
 - __opts.cache:__ default: `undefined`. Override default class cache used by
   `state.cache`. Can be a a `number` (maximum number of instances in cache,
   default `100`) or an `object` with a [nanolru][nanolru]-compatible API.
-- __opts.hash:__ default: `true`. Treat hashes in URLs as part of the pathname,
+- __opts.hash:__ default: `false`. Treat hashes in URLs as part of the pathname,
   transforming `/foo#bar` to `/foo/bar`. This is useful if the application is
   not mounted at the website root.
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function Choo (opts) {
   // properties for internal use only
   this._historyEnabled = opts.history === undefined ? true : opts.history
   this._hrefEnabled = opts.href === undefined ? true : opts.href
-  this._hashEnabled = opts.hash === undefined ? true : opts.hash
+  this._hashEnabled = opts.hash === undefined ? false : opts.hash
   this._hasWindow = typeof window !== 'undefined'
   this._cache = opts.cache
   this._loaded = false

--- a/test/browser.js
+++ b/test/browser.js
@@ -52,7 +52,7 @@ tape('should expose a public API', function (t) {
   t.end()
 })
 
-tape('should enable history and hash by defaut', function (t) {
+tape('should enable history and href by defaut', function (t) {
   var app = choo()
   t.true(app._historyEnabled, 'history enabled')
   t.true(app._hrefEnabled, 'href enabled')
@@ -82,9 +82,9 @@ tape('router should support a default route', function (t) {
   app.mount(container)
 })
 
-tape('router should treat hashes as slashes by default', function (t) {
+tape('enabling hash routing should treat hashes as slashes', function (t) {
   t.plan(1)
-  var app = choo()
+  var app = choo({ hash: true })
   var container = init('/account#security')
   app.route('/account/security', function (state, emit) {
     t.pass()
@@ -93,9 +93,9 @@ tape('router should treat hashes as slashes by default', function (t) {
   app.mount(container)
 })
 
-tape('router should ignore hashes if hash is disabled', function (t) {
+tape('router should ignore hashes by default', function (t) {
   t.plan(1)
-  var app = choo({ hash: false })
+  var app = choo()
   var container = init('/account#security')
   app.route('/account', function (state, emit) {
     t.pass()

--- a/test/node.js
+++ b/test/node.js
@@ -76,9 +76,9 @@ tape('router should support a default route', function (t) {
   t.end()
 })
 
-tape('router should treat hashes as slashes by default', function (t) {
+tape('enabling hash routing should treat hashes as slashes', function (t) {
   t.plan(1)
-  var app = choo()
+  var app = choo({ hash: true })
   app.route('/account/security', function (state, emit) {
     t.pass()
     return html`<div></div>`
@@ -87,9 +87,9 @@ tape('router should treat hashes as slashes by default', function (t) {
   t.end()
 })
 
-tape('router should ignore hashes if hash is disabled', function (t) {
+tape('router should ignore hashes by default', function (t) {
   t.plan(1)
-  var app = choo({ hash: false })
+  var app = choo()
   app.route('/account', function (state, emit) {
     t.pass()
     return html`<div></div>`


### PR DESCRIPTION
As per the discussion when the hash option was introduced https://github.com/choojs/choo/pull/667#issuecomment-403816157, this disables hash routing by default – making it an opt-in feature.