### PR TITLE
Type improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,11 @@
-/// <reference types="node" />
-
-import * as EventEmitter from 'events'
+import Nanobus = require('nanobus')
 
 export = Choo
 
 declare class Choo {
   constructor (opts?: Choo.IChoo)
-  use (callback: (state: Choo.IState, emitter: EventEmitter, app: this) => void): void
-  route (routeName: string, handler: (state: Choo.IState, emit: (name: string, ...args: any[]) => void) => void): void
+  use (callback: (state: Choo.IState, emitter: Nanobus, app: this) => void): void
+  route (routeName: string, handler: (state: Choo.IState, emit: Nanobus['emit']) => void): void
   mount (selector: string): void
   start (): HTMLElement
   toString (location: string, state?: Choo.IState): string

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,12 @@ declare namespace Choo {
     history?: boolean
     href?: boolean
     hash?: boolean
+    cache?: number | ICache
+  }
+
+  export interface ICache {
+    get(id: string | number): undefined | null | any
+    set(id: string | number, element: any): void
   }
 
   export interface IState {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,29 @@
+import { expectAssignable, expectType } from 'tsd'
+import Choo = require('.')
+
+new Choo({})
+new Choo()
+
+const app = new Choo({
+  history: false,
+  href: true,
+})
+
+app.use((state, emitter) => {
+  state.title = 'choo choo'
+  emitter.on(state.events.DOMCONTENTLOADED, () => {
+    emitter.emit('example')
+  })
+})
+
+app.route('/', (state, emit) => {
+  expectAssignable<object>(state.params)
+  expectType<string>(state.href)
+  expectType<string>(state.route)
+  expectType<string>(state.title)
+  emit('example')
+})
+
+expectType<string>(app.toString('/'))
+
+app.mount('body')

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,6 +4,17 @@ import Choo = require('.')
 new Choo({})
 new Choo()
 
+new Choo({ cache: 100 })
+new Choo({
+  cache: new Map()
+})
+new Choo({
+  cache: {
+    get: (id) => null,
+    set: (id, value) => expectType<any>(value)
+  }
+})
+
 const app = new Choo({
   history: false,
   href: true,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "inspect": "browserify --full-paths index -p tinyify | discify --open",
     "prepublishOnly": "npm run build",
     "start": "bankai start example",
-    "test": "standard && npm run deps && npm run test:node && npm run test:browser",
+    "test": "standard && npm run deps && npm run test:types && npm run test:node && npm run test:browser",
+    "test:types": "tsd",
     "test:node": "node test/node.js | tap-format-spec",
     "test:browser": "browserify test/browser.js | tape-run | tap-format-spec"
   },
@@ -40,7 +41,7 @@
   "dependencies": {
     "document-ready": "^2.0.1",
     "nanoassert": "^1.1.0",
-    "nanobus": "^4.2.0",
+    "nanobus": "^4.4.0",
     "nanocomponent": "^6.5.0",
     "nanohref": "^3.0.0",
     "nanohtml": "^1.1.0",
@@ -54,7 +55,6 @@
   },
   "devDependencies": {
     "@tap-format/spec": "^0.2.0",
-    "@types/node": "^10.3.1",
     "browserify": "^16.2.2",
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^3.1.0",
@@ -65,6 +65,14 @@
     "standard": "^11.0.1",
     "tape": "^4.6.3",
     "tape-run": "^6.0.0",
-    "tinyify": "^2.2.0"
+    "tinyify": "^2.2.0",
+    "tsd": "^0.11.0"
+  },
+  "tsd": {
+    "compilerOptions": {
+      "lib": [
+        "DOM"
+      ]
+    }
   }
 }


### PR DESCRIPTION
- add type tests
- use actual `nanobus` types instead of the similar but not identical EventEmitter types
- add type for `cache` option